### PR TITLE
nfc-amiibo: Don't leave TTY in locked state for TTY based NFC readers

### DIFF
--- a/nfc-amiibo.cpp
+++ b/nfc-amiibo.cpp
@@ -21,4 +21,7 @@ int main(int argc, char** argv) {
   NFCHandler *nfc = new NFCHandler();
 
   nfc->writeAmiibo(amiibo);
+
+  delete nfc;
+  delete amiibo;
 }

--- a/nfchandler.cpp
+++ b/nfchandler.cpp
@@ -41,6 +41,10 @@ NFCHandler::NFCHandler() {
   printf("NFC reader: opened\n");
 }
 
+NFCHandler::~NFCHandler() {
+    nfc_close(device);
+}
+
 void NFCHandler::readTagUUID(uint8_t uuidBuffer[]) {
   printf("***Scan tag***\n");
 

--- a/nfchandler.h
+++ b/nfchandler.h
@@ -8,6 +8,7 @@ class Amiibo;
 class NFCHandler {
 public:
   NFCHandler();
+  ~NFCHandler();
   void readTagUUID(uint8_t uuidBuffer[]);
   void writeAmiibo(Amiibo *amiibo);
 


### PR DESCRIPTION
Summary:
  nfc-amiibo: properly delete allocated items, so that destructor is called.
  nfchandler: properly close NFC handle on destruction